### PR TITLE
Update Dockerfile pterodactyl panel to v.1.11.11

### DIFF
--- a/pterodactyl-panel-app/Dockerfile
+++ b/pterodactyl-panel-app/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine AS download
-ARG pterodactyl_panel_version=v1.11.10
+ARG pterodactyl_panel_version=v1.11.11
 RUN apk add --no-cache \
         curl \
         tar

--- a/pterodactyl-panel-app/Dockerfile
+++ b/pterodactyl-panel-app/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine AS download
-ARG pterodactyl_panel_version=v1.11.11
+ARG pterodactyl_panel_version=v1.12
 RUN apk add --no-cache \
         curl \
         tar

--- a/pterodactyl-panel-app/Dockerfile
+++ b/pterodactyl-panel-app/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine AS download
-ARG pterodactyl_panel_version=v1.12
+ARG pterodactyl_panel_version=v1.12.1
 RUN apk add --no-cache \
         curl \
         tar


### PR DESCRIPTION
v1.11.10 has a CVSS 10 vulnerbility

Please pull this update! 

https://github.com/pterodactyl/panel/security
https://www.cve.org/CVERecord?id=CVE-2025-49132
https://github.com/pterodactyl/panel/releases/tag/v1.11.11